### PR TITLE
VEP a max_{mem,cpus} process; Rolls back to default trace

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2869,7 +2869,8 @@ compressVCFsnpEffOut = compressVCFsnpEffOut.dump(tag:'VCF')
 
 process VEP {
     label 'VEP'
-    label 'cpus_4'
+    label 'max_cpus'
+    label 'max_memory'
 
     echo true
     tag {"${idSample} - ${variantCaller} - ${vcf}"}


### PR DESCRIPTION
This PR updates:

- resource allocation for VEP (max as 1 sample per instance)
- Rolls back to default trace filepath